### PR TITLE
Fixes for Notepad++ recipe

### DIFF
--- a/Disabled/Notepad++.xml
+++ b/Disabled/Notepad++.xml
@@ -9,8 +9,10 @@
 	</Application>
 	<Downloads>
 		<Download DeploymentType="DeploymentType1">
-			<PrefetchScript>$LinkPath = ((Invoke-WebRequest https://github.com/notepad-plus-plus/notepad-plus-plus/releases/latest -UseBasicParsing)| Select-Object -ExpandProperty Links | Where-Object -Property href -Like "*npp.*.Installer.exe").href
-			$URL = "https://github.com$LinkPath"</PrefetchScript>
+			<PrefetchScript>[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+				$LinkPath = ((Invoke-WebRequest https://github.com/notepad-plus-plus/notepad-plus-plus/releases/latest -UseBasicParsing)| Select-Object -ExpandProperty Links | Where-Object -Property href -Like "*npp.*.Installer.exe").href
+				$URL = "https://github.com$LinkPath"
+			</PrefetchScript>
 			<URL></URL>
 			<DownloadFileName>NotePadppInstaller.exe</DownloadFileName>
 			<Version></Version>

--- a/Disabled/Notepad++.xml
+++ b/Disabled/Notepad++.xml
@@ -10,8 +10,7 @@
 	<Downloads>
 		<Download DeploymentType="DeploymentType1">
 			<PrefetchScript>[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-				$LinkPath = ((Invoke-WebRequest https://github.com/notepad-plus-plus/notepad-plus-plus/releases/latest -UseBasicParsing)| Select-Object -ExpandProperty Links | Where-Object -Property href -Like "*npp.*.Installer.exe").href
-				$URL = "https://github.com$LinkPath"
+				$URL = ((Invoke-WebRequest "https://api.github.com/repos/notepad-plus-plus/notepad-plus-plus/releases/latest" | ConvertFrom-Json)[0].assets | where { $_.name -Like "*npp.*.Installer.exe" }[0]).browser_download_url
 			</PrefetchScript>
 			<URL></URL>
 			<DownloadFileName>NotePadppInstaller.exe</DownloadFileName>

--- a/Recipes/Template.xml
+++ b/Recipes/Template.xml
@@ -13,7 +13,7 @@
 		<UserDocumentation></UserDocumentation>
 		<!-- Icon - [String] Icon File Name in Icon Repository (Repository is set in the Preferences File) -->
 		<Icon></Icon>
-		<!-- FolderPath - [String] The folder path folder path in ConfigMgr where the Application should be created. Default location on the "Software Libary" node is the root under "Overview -> Application Management -> Applications". -->
+		<!-- FolderPath - [String] The folder path in ConfigMgr where the Application should be created. Default location on the "Software Libary" node is the root under "Overview -> Application Management -> Applications". -->
 		<FolderPath></FolderPath>
 	</Application>
 	<!-- Downloads - Sets the Definition for the downloads required for the Application -->


### PR DESCRIPTION
Running the Notepad++ recipe results in the following error.

````
Invoke-WebRequest : The request was aborted: Could not create SSL/TLS secure channel.
At line:1 char:3
+ ((Invoke-WebRequest https://github.com/notepad-plus-plus/notepad-plus-plus/relea ...
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (System.Net.HttpWebRequest:HttpWebRequest) [Invoke-WebRequest], WebExc
   eption
    + FullyQualifiedErrorId : WebCmdletWebResponseException,Microsoft.PowerShell.Commands.InvokeWebRequestCommand
````

Setting the `SecurityProtocol` to `Tls12` in the recipes `PrefetchScript` fixes the issue
````
[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
````

