### PR TITLE
New Feature: Application Supersedence

### DIFF
--- a/CMPackager.ps1
+++ b/CMPackager.ps1
@@ -1754,7 +1754,7 @@ Combines the output from Get-ChildItem with the Get-ExtensionAttribute function,
 		}
 		If ($ApplicationDistribution) {
 			Write-Output "Application Supersedence"
-			$ApplicationSupersedence = Invoke-ApplicationSupersedence $ApplicationRecipe
+			$ApplicationSupersedence = Invoke-ApplicationSupersedence -Recipe $ApplicationRecipe
 			Add-LogContent "Continue to Application Deployment: $ApplicationSupersedence"
 		}
 		If ($ApplicationSupersedence) {

--- a/CMPackager.ps1
+++ b/CMPackager.ps1
@@ -1380,8 +1380,9 @@ Combines the output from Get-ChildItem with the Get-ExtensionAttribute function,
 
 				if ($NewAppDeploymentTypes.LocalizedDisplayName -eq $OldAppDeploymentTypes.LocalizedDisplayName) {
 					Foreach ($DeploymentType in $NewAppDeploymentTypes) {
+						Write-Host "Superseding $($DeploymentType.LocalizedDisplayName)"
 						$SupersededDeploymentType = $OldAppDeploymentTypes | Where-Object LocalizedDisplayName -eq $DeploymentType.LocalizedDisplayName
-						Add-CMDeploymentTypeSupersedence -SupersedingDeploymentType $DeploymentType -SupersededDeploymentType $SupersededDeploymentType | out-null
+						Add-CMDeploymentTypeSupersedence -SupersedingDeploymentType $DeploymentType -SupersededDeploymentType $SupersededDeploymentType
 					}
 				}
 			}

--- a/CMPackager.ps1
+++ b/CMPackager.ps1
@@ -1370,6 +1370,7 @@ Combines the output from Get-ChildItem with the Get-ExtensionAttribute function,
 			Push-Location
 			Set-Location $CMSite
 			$Latest2Apps = Get-CMApplication -Name "$ApplicationName*" -Fast | Where-Object Publisher -eq $ApplicationPublisher | Sort-Object DateCreated | Select-Object -first 2
+			Write-Host "Latest 2 apps = $($Latest2Apps.LocalizedDisplayName)"
 			if ($Latest2Apps.Count -eq 2) {
 				$NewApp = $Latest2Apps | Select-Object -First 1
 				$OldApp = $Latest2Apps | Select-Object -Last 1

--- a/CMPackager.ps1
+++ b/CMPackager.ps1
@@ -1369,7 +1369,7 @@ Combines the output from Get-ChildItem with the Get-ExtensionAttribute function,
 			# Get the Previous Application Deployment Type
 			Push-Location
 			Set-Location $CMSite
-			$Latest2Apps = Get-CMApplication -Name "$ApplicationName*" -Fast | Where-Object Publisher -eq $ApplicationPublisher | Sort-Object DateCreated | Select-Object -first 2
+			$Latest2Apps = Get-CMApplication -Name "$ApplicationName*" -Fast | Where-Object Manufacturer -eq $ApplicationPublisher | Sort-Object DateCreated | Select-Object -first 2
 			Write-Host "Latest 2 apps = $($Latest2Apps.LocalizedDisplayName)"
 			if ($Latest2Apps.Count -eq 2) {
 				$NewApp = $Latest2Apps | Select-Object -First 1

--- a/CMPackager.ps1
+++ b/CMPackager.ps1
@@ -1364,7 +1364,7 @@ Combines the output from Get-ChildItem with the Get-ExtensionAttribute function,
 		$ApplicationName = $Recipe.ApplicationDef.Application.Name
 		$ApplicationPublisher = $Recipe.ApplicationDef.Application.Publisher
 		$SupersedenceEnabled = [System.Convert]::ToBoolean($Recipe.ApplicationDef.Supersedence)
-
+		Write-Output "Supersedence is $SupersedenceEnabled"
 		if ($SupersedenceEnabled) {
 			# Get the Previous Application Deployment Type
 			Push-Location
@@ -1373,12 +1373,13 @@ Combines the output from Get-ChildItem with the Get-ExtensionAttribute function,
 			if ($Latest2Apps.Count -eq 2) {
 				$NewApp = $Latest2Apps[0]
 				$OldApp = $Latest2Apps[1]
-		
+				Write-Output $oldapp.LocalizedDisplayName $newapp.LocalizedDisplayName
 				# Check that the DeploymentTypes and Deployment Type Names Match if not, skip supersedence
 				$NewAppDeploymentTypes = Get-CMDeploymentType -ApplicationName $NewApp.LocalizedDisplayName
 				$OldAppDeploymentTypes = Get-CMDeploymentType -ApplicationName $OldApp.LocalizedDisplayName
 
 				if ($NewAppDeploymentTypes.LocalizedDisplayName -eq $OldAppDeploymentTypes.LocalizedDisplayName) {
+					Write-Output "New and Old App Deployment Type Names Match"
 					Foreach ($DeploymentType in $NewAppDeploymentTypes) {
 						Write-Host "Superseding $($DeploymentType.LocalizedDisplayName)"
 						$SupersededDeploymentType = $OldAppDeploymentTypes | Where-Object LocalizedDisplayName -eq $DeploymentType.LocalizedDisplayName

--- a/CMPackager.ps1
+++ b/CMPackager.ps1
@@ -1364,22 +1364,22 @@ Combines the output from Get-ChildItem with the Get-ExtensionAttribute function,
 		$ApplicationName = $Recipe.ApplicationDef.Application.Name
 		$ApplicationPublisher = $Recipe.ApplicationDef.Application.Publisher
 		$SupersedenceEnabled = [System.Convert]::ToBoolean($Recipe.ApplicationDef.Supersedence)
-		Write-Output "Supersedence is $SupersedenceEnabled"
+		Write-Host "Supersedence is $SupersedenceEnabled"
 		if ($SupersedenceEnabled) {
 			# Get the Previous Application Deployment Type
 			Push-Location
 			Set-Location $CMSite
 			$Latest2Apps = Get-CMApplication -Name "$ApplicationName*" -Fast | Where-Object Publisher -eq $ApplicationPublisher | Sort-Object DateCreated | Select-Object -first 2
 			if ($Latest2Apps.Count -eq 2) {
-				$NewApp = $Latest2Apps[0]
-				$OldApp = $Latest2Apps[1]
-				Write-Output $oldapp.LocalizedDisplayName $newapp.LocalizedDisplayName
+				$NewApp = $Latest2Apps | Select-Object -First 1
+				$OldApp = $Latest2Apps | Select-Object -Last 1
+				Write-Host $oldapp.LocalizedDisplayName $newapp.LocalizedDisplayName
 				# Check that the DeploymentTypes and Deployment Type Names Match if not, skip supersedence
 				$NewAppDeploymentTypes = Get-CMDeploymentType -ApplicationName $NewApp.LocalizedDisplayName
 				$OldAppDeploymentTypes = Get-CMDeploymentType -ApplicationName $OldApp.LocalizedDisplayName
 
 				if ($NewAppDeploymentTypes.LocalizedDisplayName -eq $OldAppDeploymentTypes.LocalizedDisplayName) {
-					Write-Output "New and Old App Deployment Type Names Match"
+					Write-Host "New and Old App Deployment Type Names Match"
 					Foreach ($DeploymentType in $NewAppDeploymentTypes) {
 						Write-Host "Superseding $($DeploymentType.LocalizedDisplayName)"
 						$SupersededDeploymentType = $OldAppDeploymentTypes | Where-Object LocalizedDisplayName -eq $DeploymentType.LocalizedDisplayName
@@ -1750,7 +1750,7 @@ Combines the output from Get-ChildItem with the Get-ExtensionAttribute function,
 		If ($DeploymentTypeCreation) {
 			Write-Output "Application Distribution"
 			$ApplicationDistribution = Invoke-ApplicationDistribution -Recipe $ApplicationRecipe
-			Add-LogContent "Continue to ApplicationSupersedence: $ApplicationDistribution"
+			Add-LogContent "Continue to Application Supersedence: $ApplicationDistribution"
 		}
 		If ($ApplicationDistribution) {
 			Write-Output "Application Supersedence"

--- a/CMPackager.ps1
+++ b/CMPackager.ps1
@@ -2,7 +2,7 @@
 	.NOTES
 	===========================================================================
 	 Created on:   	1/9/2018 11:34 AM
-	 Last Updated:  12/31/2019
+	 Last Updated:  03/29/2020
 	 Author:		Andrew Jimenez (asjimene) - https://github.com/asjimene/
 	 Filename:     	CMPackager.ps1
 	===========================================================================
@@ -37,7 +37,7 @@ DynamicParam {
 }
 process {
 
-	$Global:ScriptVersion = "20.02.23.0"
+	$Global:ScriptVersion = "20.03.29.0"
 
 	$Global:ScriptRoot = $PSScriptRoot
 

--- a/CMPackager.ps1
+++ b/CMPackager.ps1
@@ -1363,7 +1363,20 @@ Combines the output from Get-ChildItem with the Get-ExtensionAttribute function,
 
 		$ApplicationName = $Recipe.ApplicationDef.Application.Name
 		$ApplicationPublisher = $Recipe.ApplicationDef.Application.Publisher
-		$SupersedenceEnabled = [System.Convert]::ToBoolean($Recipe.ApplicationDef.Supersedence)
+		If (-not ([string]::IsNullOrEmpty($Recipe.ApplicationDef.Supersedence.Supersedence))) {
+			$SupersedenceEnabled = [System.Convert]::ToBoolean($Recipe.ApplicationDef.Supersedence.Supersedence)
+		}
+		else {
+			$SupersedenceEnabled = $false
+		}
+
+		If (-not ([string]::IsNullOrEmpty($Recipe.ApplicationDef.Supersedence.Uninstall))) {
+			$UninstallOldApp = [System.Convert]::ToBoolean($Recipe.ApplicationDef.Supersedence.Uninstall)
+		}
+		else {
+			$UninstallOldApp = $false
+		}
+
 		Write-Host "Supersedence is $SupersedenceEnabled"
 		if ($SupersedenceEnabled) {
 			# Get the Previous Application Deployment Type
@@ -1383,7 +1396,12 @@ Combines the output from Get-ChildItem with the Get-ExtensionAttribute function,
 				Foreach ($DeploymentType in $NewAppDeploymentTypes) {
 					Write-Host "Superseding $($DeploymentType.LocalizedDisplayName)"
 					$SupersededDeploymentType = $OldAppDeploymentTypes | Where-Object LocalizedDisplayName -eq $DeploymentType.LocalizedDisplayName
-					Add-CMDeploymentTypeSupersedence -SupersedingDeploymentType $DeploymentType -SupersededDeploymentType $SupersededDeploymentType | Out-Null
+					if ($UninstallOldApp) {
+						Add-CMDeploymentTypeSupersedence -SupersedingDeploymentType $DeploymentType -SupersededDeploymentType $SupersededDeploymentType -Uninstall | Out-Null
+					}
+					else {
+						Add-CMDeploymentTypeSupersedence -SupersedingDeploymentType $DeploymentType -SupersededDeploymentType $SupersededDeploymentType | Out-Null
+					}
 				}
 			}
 			Pop-Location

--- a/CMPackager.ps1
+++ b/CMPackager.ps1
@@ -1580,7 +1580,7 @@ Combines the output from Get-ChildItem with the Get-ExtensionAttribute function,
 				Connect-ConfigMgr
 				Push-Location
 				Set-Location $Global:CMSite
-				(Get-CMDeviceCollection "$($WPFcomboBoxPreferredDeployColl.Text)*") | ForEach-Object { $WPFcomboBoxPreferredDeployColl.Items.Add($_.Name) }
+				(Get-CMDeviceCollection -CollectionName "$($WPFcomboBoxPreferredDeployColl.Text)*") | ForEach-Object { $WPFcomboBoxPreferredDeployColl.Items.Add($_.Name) }
 				Pop-Location
 				$form.Cursor = "Arrow"
 			})

--- a/CMPackager.ps1
+++ b/CMPackager.ps1
@@ -1376,8 +1376,8 @@ Combines the output from Get-ChildItem with the Get-ExtensionAttribute function,
 				$OldApp = $Latest2Apps | Select-Object -Last 1
 				Write-Host $oldapp.LocalizedDisplayName $newapp.LocalizedDisplayName
 				# Check that the DeploymentTypes and Deployment Type Names Match if not, skip supersedence
-				$NewAppDeploymentTypes = Get-CMDeploymentType -ApplicationName $NewApp.LocalizedDisplayName
-				$OldAppDeploymentTypes = Get-CMDeploymentType -ApplicationName $OldApp.LocalizedDisplayName
+				$NewAppDeploymentTypes = Get-CMDeploymentType -ApplicationName $NewApp.LocalizedDisplayName | Sort-Object LocalizedDisplayName
+				$OldAppDeploymentTypes = Get-CMDeploymentType -ApplicationName $OldApp.LocalizedDisplayName | Sort-Object LocalizedDisplayName
 
 				if ($NewAppDeploymentTypes.LocalizedDisplayName -eq $OldAppDeploymentTypes.LocalizedDisplayName) {
 					Write-Host "New and Old App Deployment Type Names Match"

--- a/CMPackager.ps1
+++ b/CMPackager.ps1
@@ -1580,7 +1580,7 @@ Combines the output from Get-ChildItem with the Get-ExtensionAttribute function,
 				Connect-ConfigMgr
 				Push-Location
 				Set-Location $Global:CMSite
-				(Get-CMDeviceCollection -CollectionName "$($WPFcomboBoxPreferredDeployColl.Text)*") | ForEach-Object { $WPFcomboBoxPreferredDeployColl.Items.Add($_.Name) }
+				(Get-CMDeviceCollection -Name "$($WPFcomboBoxPreferredDeployColl.Text)*") | ForEach-Object { $WPFcomboBoxPreferredDeployColl.Items.Add($_.Name) }
 				Pop-Location
 				$form.Cursor = "Arrow"
 			})

--- a/CMPackager.ps1
+++ b/CMPackager.ps1
@@ -1397,7 +1397,7 @@ Combines the output from Get-ChildItem with the Get-ExtensionAttribute function,
 					Write-Host "Superseding $($DeploymentType.LocalizedDisplayName)"
 					$SupersededDeploymentType = $OldAppDeploymentTypes | Where-Object LocalizedDisplayName -eq $DeploymentType.LocalizedDisplayName
 					if ($UninstallOldApp) {
-						Add-CMDeploymentTypeSupersedence -SupersedingDeploymentType $DeploymentType -SupersededDeploymentType $SupersededDeploymentType -Uninstall | Out-Null
+						Add-CMDeploymentTypeSupersedence -SupersedingDeploymentType $DeploymentType -SupersededDeploymentType $SupersededDeploymentType -IsUninstall | Out-Null
 					}
 					else {
 						Add-CMDeploymentTypeSupersedence -SupersedingDeploymentType $DeploymentType -SupersededDeploymentType $SupersededDeploymentType | Out-Null

--- a/CMPackager.ps1
+++ b/CMPackager.ps1
@@ -1397,7 +1397,7 @@ Combines the output from Get-ChildItem with the Get-ExtensionAttribute function,
 					Write-Host "Superseding $($DeploymentType.LocalizedDisplayName)"
 					$SupersededDeploymentType = $OldAppDeploymentTypes | Where-Object LocalizedDisplayName -eq $DeploymentType.LocalizedDisplayName
 					if ($UninstallOldApp) {
-						Add-CMDeploymentTypeSupersedence -SupersedingDeploymentType $DeploymentType -SupersededDeploymentType $SupersededDeploymentType -IsUninstall | Out-Null
+						Add-CMDeploymentTypeSupersedence -SupersedingDeploymentType $DeploymentType -SupersededDeploymentType $SupersededDeploymentType -IsUninstall $true | Out-Null
 					}
 					else {
 						Add-CMDeploymentTypeSupersedence -SupersedingDeploymentType $DeploymentType -SupersededDeploymentType $SupersededDeploymentType | Out-Null

--- a/CMPackager.ps1
+++ b/CMPackager.ps1
@@ -1372,20 +1372,18 @@ Combines the output from Get-ChildItem with the Get-ExtensionAttribute function,
 			$Latest2Apps = Get-CMApplication -Name "$ApplicationName*" -Fast | Where-Object Manufacturer -eq $ApplicationPublisher | Sort-Object DateCreated | Select-Object -first 2
 			Write-Host "Latest 2 apps = $($Latest2Apps.LocalizedDisplayName)"
 			if ($Latest2Apps.Count -eq 2) {
-				$NewApp = $Latest2Apps | Select-Object -First 1
-				$OldApp = $Latest2Apps | Select-Object -Last 1
-				Write-Host $oldapp.LocalizedDisplayName $newapp.LocalizedDisplayName
+				$NewApp = $Latest2Apps | Select-Object -Last 1
+				$OldApp = $Latest2Apps | Select-Object -First 1
+				Write-Host "Old: $($oldapp.LocalizedDisplayName) New: $($newapp.LocalizedDisplayName)"
+
 				# Check that the DeploymentTypes and Deployment Type Names Match if not, skip supersedence
 				$NewAppDeploymentTypes = Get-CMDeploymentType -ApplicationName $NewApp.LocalizedDisplayName | Sort-Object LocalizedDisplayName
 				$OldAppDeploymentTypes = Get-CMDeploymentType -ApplicationName $OldApp.LocalizedDisplayName | Sort-Object LocalizedDisplayName
 
-				if ($NewAppDeploymentTypes.LocalizedDisplayName -eq $OldAppDeploymentTypes.LocalizedDisplayName) {
-					Write-Host "New and Old App Deployment Type Names Match"
-					Foreach ($DeploymentType in $NewAppDeploymentTypes) {
-						Write-Host "Superseding $($DeploymentType.LocalizedDisplayName)"
-						$SupersededDeploymentType = $OldAppDeploymentTypes | Where-Object LocalizedDisplayName -eq $DeploymentType.LocalizedDisplayName
-						Add-CMDeploymentTypeSupersedence -SupersedingDeploymentType $DeploymentType -SupersededDeploymentType $SupersededDeploymentType
-					}
+				Foreach ($DeploymentType in $NewAppDeploymentTypes) {
+					Write-Host "Superseding $($DeploymentType.LocalizedDisplayName)"
+					$SupersededDeploymentType = $OldAppDeploymentTypes | Where-Object LocalizedDisplayName -eq $DeploymentType.LocalizedDisplayName
+					Add-CMDeploymentTypeSupersedence -SupersedingDeploymentType $DeploymentType -SupersededDeploymentType $SupersededDeploymentType | Out-Null
 				}
 			}
 			Pop-Location

--- a/Recipes/Template.xml
+++ b/Recipes/Template.xml
@@ -334,6 +334,8 @@
 		<!-- DistributeToGroup - [String] Name of Distribution Point Group to distribute the Content to -->
 		<DistributeToGroup>All DPs except PXE</DistributeToGroup>
 	</Distribution>
+	<!-- You can automatically supersede the previous version of the application (Note that the Previous version has to have the same name, publisher and deployment type names)-->>
+	<Supersedence>[Boolean]</Supersedence>
 	<!-- You can optionally deploy the application to a specified Collection here -->
 	<Deployment>
 		<!-- DeploySoftware - [Boolean] Switch for Software Deployment, Application should be distributed before deployment -->

--- a/Recipes/Template.xml
+++ b/Recipes/Template.xml
@@ -335,7 +335,12 @@
 		<DistributeToGroup>All DPs except PXE</DistributeToGroup>
 	</Distribution>
 	<!-- You can automatically supersede the previous version of the application (Note that the Previous version has to have the same name, publisher and deployment type names)-->>
-	<Supersedence>[Boolean]</Supersedence>
+	<Supersedence>
+		<!-- Supersede this application automatically -->
+		<Supersedence>[Boolean]</Supersedence>
+		<!-- Uninstall previous version before installing the latest -->
+		<Uninstall>[Boolean]</Uninstall>
+	</Supersedence>
 	<!-- You can optionally deploy the application to a specified Collection here -->
 	<Deployment>
 		<!-- DeploySoftware - [Boolean] Switch for Software Deployment, Application should be distributed before deployment -->


### PR DESCRIPTION
New Feature: Application Supersedence
- Enable Supersedence in an application's Recipe to automatically supersede the previously packaged application with the newly packaged version.

NOTE: Certain errors could result in a broken package (download URL change, etc.), in these cases, supersedence may cause issues! Ensure you understand the repercussions of supersedence before enabling it for an application!

Resolves #20  