### PR TITLE
Enable Download PreCheck feature

### DIFF
--- a/CMPackager.ps1
+++ b/CMPackager.ps1
@@ -362,8 +362,9 @@ Combines the output from Get-ChildItem with the Get-ExtensionAttribute function,
 			if (-not ([System.String]::IsNullOrEmpty($Download.Version))) {
 				## Version Check after prefetch script (skip download if possible)
 				## This was not working well. Will revisit later
-				$newApp = Invoke-VersionCheck -ApplciationName $ApplicationName -ApplciationSWVersion ([string]$Download.Version)
 				$ApplicationSWVersion = $Download.Version
+				$newApp = Invoke-VersionCheck -ApplciationName $ApplicationName -ApplciationSWVersion ([string]$ApplicationSWVersion)
+				
 				Add-LogContent "Version Check after prefetch script is $newapp Version Found is: $ApplicationSWVersion"
 				#$newApp = $true
 			}

--- a/CMPackager.ps1
+++ b/CMPackager.ps1
@@ -361,11 +361,12 @@ Combines the output from Get-ChildItem with the Get-ExtensionAttribute function,
 
 			if (-not ([System.String]::IsNullOrEmpty($Download.Version))) {
 				## Version Check after prefetch script (skip download if possible)
-				## This was not working well. Will revisit later
+				## To Set the Download Version in the Prefetch Script, Simply set the variable $Download.Version to the [String]Version of the Application
 				$ApplicationSWVersion = $Download.Version
+				Add-LogContent "Prefetch Script Provided a Download Version of: $ApplicationSWVersion"
 				$newApp = Invoke-VersionCheck -ApplciationName $ApplicationName -ApplciationSWVersion ([string]$ApplicationSWVersion)
 				
-				Add-LogContent "Version Check after prefetch script is $newapp Version Found is: $ApplicationSWVersion"
+				Add-LogContent "Version Check after prefetch script is $newapp"
 				#$newApp = $true
 			}
 			else {
@@ -403,7 +404,7 @@ Combines the output from Get-ChildItem with the Get-ExtensionAttribute function,
 			Add-LogContent "Found Version $ApplicationSWVersion from Download FullVersion: $FullVersion"
 
 			## Determine if the Download Failed or if an Application Version was not detected, and add the Failure to the email if the Flag is set
-			if ((-not (Test-Path $DownloadFile)) -or ([System.String]::IsNullOrEmpty($ApplicationSWVersion))) {
+			if (((-not (Test-Path $DownloadFile)) -and $newApp) -or ([System.String]::IsNullOrEmpty($ApplicationSWVersion))) {
 				Add-LogContent "ERROR: Failed to Download or find the Version for $ApplicationName"
 				if ($Global:NotifyOnDownloadFailure) {
 					$Global:SendEmail = $true; $Global:SendEmail | Out-Null

--- a/CMPackager.ps1
+++ b/CMPackager.ps1
@@ -342,10 +342,10 @@ Combines the output from Get-ChildItem with the Get-ExtensionAttribute function,
 			$Recipe
 		)
 		$ApplicationName = $Recipe.ApplicationDef.Application.Name
-		$newApp = $false
 
 		ForEach ($Download In $Recipe.ApplicationDef.Downloads.ChildNodes) {
 			## Set Variables
+			$newApp = $false
 			$DownloadFileName = $Download.DownloadFileName
 			$URL = $Download.URL
 			$DownloadVersionCheck = $Download.DownloadVersionCheck
@@ -363,13 +363,15 @@ Combines the output from Get-ChildItem with the Get-ExtensionAttribute function,
 				## Version Check after prefetch script (skip download if possible)
 				## This was not working well. Will revisit later
 				$newApp = Invoke-VersionCheck -ApplciationName $ApplicationName -ApplciationSWVersion ([string]$Download.Version)
+				$ApplicationSWVersion = $Download.Version
+				Add-LogContent "Version Check after prefetch script is $newapp Version Found is: $ApplicationSWVersion"
 				#$newApp = $true
 			}
 			else {
 				$newApp = $true
 			}
 			
-			Add-LogContent "Version Check after prefetch script is $newapp"
+			
 
 			## Download the Application
 			If ((-not ([String]::IsNullOrEmpty($URL))) -and ($newapp)) {

--- a/CMPackager.ps1
+++ b/CMPackager.ps1
@@ -359,11 +359,11 @@ Combines the output from Get-ChildItem with the Get-ExtensionAttribute function,
 				Invoke-Expression $PrefetchScript | Out-Null
 			}
 
-			if (-not ([System.String]::IsNullOrEmpty($Version))) {
+			if (-not ([System.String]::IsNullOrEmpty($Download.Version))) {
 				## Version Check after prefetch script (skip download if possible)
 				## This was not working well. Will revisit later
-				#$newApp = Invoke-VersionCheck -ApplciationName $ApplicationName -ApplciationSWVersion ([string]$Version)
-				$newApp = $true
+				$newApp = Invoke-VersionCheck -ApplciationName $ApplicationName -ApplciationSWVersion ([string]$Download.Version)
+				#$newApp = $true
 			}
 			else {
 				$newApp = $true
@@ -392,9 +392,10 @@ Combines the output from Get-ChildItem with the Get-ExtensionAttribute function,
 			## Run the Version Check Script and record the Version and FullVersion
 			If (-not ([String]::IsNullOrEmpty($DownloadVersionCheck))) {
 				Invoke-Expression $DownloadVersionCheck | Out-Null
+				$Download.Version = [string]$Version
+				$Download.FullVersion = [string]$FullVersion
 			}
-			$Download.Version = [string]$Version
-			$Download.FullVersion = [string]$FullVersion
+
 			$ApplicationSWVersion = $Download.Version
 			Add-LogContent "Found Version $ApplicationSWVersion from Download FullVersion: $FullVersion"
 

--- a/Disabled/JetBrains-Toolbox.xml
+++ b/Disabled/JetBrains-Toolbox.xml
@@ -13,13 +13,14 @@
 			$json = Invoke-WebRequest $releases | ConvertFrom-Json
 			$LinkPath = $json.TBA.downloads.windows.link
 			$Version = "$($json.TBA.build)"
+			$Download.Version = $Version
 			$URL = $LinkPath
 			</PrefetchScript>
 			<URL></URL>
 			<DownloadFileName>jetbrains-toolbox.exe</DownloadFileName>
 			<Version></Version>
 			<FullVersion></FullVersion>
-			<DownloadVersionCheck>$Version</DownloadVersionCheck>
+			<DownloadVersionCheck></DownloadVersionCheck>
 			<ExtraCopyFunctions></ExtraCopyFunctions>
 		</Download>
 	</Downloads>


### PR DESCRIPTION
Allows a download precheck to prevent downloading applications if the version can be determined in the prefetchscript.

To enable the download precheck for a recipe, simply assign the detected version to the variable $Download.Version in the <prefetchscript> for each download. if a version is detected after the prefetch script runs, a check will run if the app already exists in ConfigMgr, download of the app will only occur if the app is not found in ConfigMgr. Completes #24 