### PR TITLE
Add version prefetch to Firefox recipe

### DIFF
--- a/Disabled/MozillaFirefoxESR.xml
+++ b/Disabled/MozillaFirefoxESR.xml
@@ -9,16 +9,26 @@
 	</Application>
 	<Downloads>
 		<Download DeploymentType="DeploymentType1">
-			<URL>https://download.mozilla.org/?product=firefox-esr-msi-latest-ssl&amp;os=win64&amp;lang=en-US</URL>
+			<PrefetchScript>
+				$webrequest = Invoke-WebRequest 'https://download.mozilla.org/?product=firefox-esr-msi-latest-ssl&amp;os=win64&amp;lang=en-GB' -MaximumRedirection 0 -ErrorAction SilentlyContinue
+				$URL = $webrequest.Headers.Location
+				$Download.Version = [regex]::Match($URL,".*/releases/([.\d]*).*").captures.groups[1]
+			</PrefetchScript>
+			<URL></URL>
 			<DownloadFileName>FirefoxESRx64.msi</DownloadFileName>
-			<DownloadVersionCheck>$Version = ([String](Get-MSIInfo -Path $DownloadFile -Property ProductVersion)).TrimStart().TrimEnd()</DownloadVersionCheck>
+			<DownloadVersionCheck>$Version = $Download.Version</DownloadVersionCheck>
 			<FullVersion></FullVersion>
 			<Version></Version>
 		</Download>
 		<Download DeploymentType="DeploymentType2">
-			<URL>https://download.mozilla.org/?product=firefox-esr-msi-latest-ssl&amp;os=win&amp;lang=en-US</URL>
+			<PrefetchScript>
+				$webrequest = Invoke-WebRequest 'https://download.mozilla.org/?product=firefox-esr-msi-latest-ssl&amp;os=win&amp;lang=en-GB' -MaximumRedirection 0 -ErrorAction SilentlyContinue
+				$URL = $webrequest.Headers.Location
+				$Download.Version = [regex]::Match($URL,".*/releases/([.\d]*).*").captures.groups[1]
+			</PrefetchScript>
+			<URL></URL>
 			<DownloadFileName>FirefoxESRx86.msi</DownloadFileName>
-			<DownloadVersionCheck>$Version = ([String](Get-MSIInfo -Path $DownloadFile -Property ProductVersion)).TrimStart().TrimEnd()</DownloadVersionCheck>
+			<DownloadVersionCheck>$Version = $Download.Version</DownloadVersionCheck>
 			<FullVersion></FullVersion>
 			<Version></Version>
 		</Download>


### PR DESCRIPTION
The MSI version has a trailing ".0" which means we can't necessarily compare that version against the download version. Need to use the version in the URL instead for consistency.