### PR TITLE
Add preference for custom PS module path

### DIFF
--- a/CMPackager.prefs.template
+++ b/CMPackager.prefs.template
@@ -8,6 +8,8 @@
 	<ContentLocationRoot>\\server\share\Apps\All</ContentLocationRoot>
 	<!-- IconRepo - [String] Repository for Application Icons to be used in software Center -->
 	<IconRepo>\\Server\Share\Apps\Application Icons</IconRepo>
+	<!-- CMPSModulePath - [String] Path to non-default CM PowerShell Module (e.g. C:\Temp\PSModule\bin). If not specified, look in default console install directory -->
+	<CMPSModulePath></CMPSModulePath>
 	<!-- SCCMSite - [String] SCCM Site Name -->
 	<CMSite>PS1:</CMSite>
 	<!-- FQDN of the Primary Site Server -->

--- a/CMPackager.ps1
+++ b/CMPackager.ps1
@@ -67,6 +67,7 @@ process {
 		$Global:PreferredDistributionLoc = $PackagerPrefs.PackagerPrefs.PreferredDistributionLoc
 		$Global:PreferredDeployCollection = $PackagerPrefs.PackagerPrefs.PreferredDeployCollection
 		$Global:NoVersionInSWCenter = [System.Convert]::ToBoolean($PackagerPrefs.PackagerPrefs.NoVersionInSWCenter)
+		$Global:CMPSModulePath = $PackagerPrefs.PackagerPrefs.CMPSModulePath
 
 
 		# Email Vars
@@ -1516,7 +1517,11 @@ Combines the output from Get-ChildItem with the Get-ExtensionAttribute function,
 		if (-not (Get-Module ConfigurationManager)) {
 			try {
 				Add-LogContent "Importing ConfigurationManager Module"
-				Import-Module (Join-Path $(Split-Path $env:SMS_ADMIN_UI_PATH) ConfigurationManager.psd1) -ErrorAction SilentlyContinue -WarningAction SilentlyContinue
+				if ($Global:CMPSModulePath) {
+					Import-Module (Join-Path $Global:CMPSModulePath ConfigurationManager.psd1) -ErrorAction SilentlyContinue -WarningAction SilentlyContinue
+				} else {
+					Import-Module (Join-Path $(Split-Path $env:SMS_ADMIN_UI_PATH) ConfigurationManager.psd1) -ErrorAction SilentlyContinue -WarningAction SilentlyContinue
+				}
 			} 
 			catch {
 				$ErrorMessage = $_.Exception.Message


### PR DESCRIPTION
Add preference entry for PS module location outside of console install. Defaults to SMS_ADMIN_UI_PATH if not defined. This allows for flexibility of the repository without having to install the console.