### PR TITLE
Update Invoke-ApplicationCreation function with all application fields

### DIFF
--- a/Recipes/Template.xml
+++ b/Recipes/Template.xml
@@ -1,18 +1,40 @@
 <ApplicationDef>
 	<!-- Application - Sets the information shown in SCCM and in Software Center for the Application -->
 	<Application>
-		<!-- Name - [String] The Name of the Application (version number is appended)-->
+		<!-- Name (Required) - [String] The Name of the Application (version number is appended)-->
 		<Name></Name>
-		<!-- Description - [String] Application and Software Center Description -->
+		<!-- Description - [String] Software Center Description -->
 		<Description></Description>
+		<!-- AdminDescription - [String] Application Administrative Description -->
+		<AdminDescription></AdminDescription>
 		<!-- Publisher - [String] Application Publisher -->
 		<Publisher></Publisher>
 		<!-- AutoInstall - [Boolean] Allow Install In Task Sequence -->
 		<AutoInstall></AutoInstall>
-		<!-- UserDocumentation - [String] Information Link for Software Center -->
+		<!-- UserDocumentation - [String] Hyperlink, in URI format for information for Software Center -->
 		<UserDocumentation></UserDocumentation>
+		<!-- OptionalReference - [String] Reference Link in Admin Console -->
+		<OptionalReference></OptionalReference>
+		<!-- LinkText - [String] Specifies a description that appears in the Application Catalog with a hyperlink to additional information or documentation for the application. -->
+		<LinkText></LinkText>
+		<!-- PrivacyUrl - [String] Hyperlink, in URI format, to privacy information about the application. -->
+		<PrivacyUrl></PrivacyUrl>
+		<!-- Owner - [String] Owner for Application -->
+		<Owner></Owner>
+		<!-- SupportContact - [String] Support Contact for Application -->
+		<SupportContact></SupportContact>
 		<!-- Icon - [String] Icon File Name in Icon Repository (Repository is set in the Preferences File) -->
 		<Icon></Icon>
+		<!-- AdminCategories - [String] Comma Delimited Categories in the Console -->
+		<AdminCategories></AdminCategories>
+		<!-- UserCategories - [String] Comma Delimited Categories for Software Center -->
+		<UserCategories></UserCategories>
+		<!-- Keywords - [String] Comma Delimited Keywords for Searching in Software Center -->
+		<Keywords></Keywords>
+		<!-- FeaturedApplication - [Boolean] Display as a Featured Application and Hightlight in the Company Portal -->
+		<FeaturedApplication></FeaturedApplication>
+		<!-- DisplaySupersedence - [Boolean] Allows Users to See Deployments Superceded Appplications in Software Center -->
+		<DisplaySupersedence></DisplaySupersedence>
 		<!-- FolderPath - [String] The folder path in ConfigMgr where the Application should be created. Default location on the "Software Libary" node is the root under "Overview -> Application Management -> Applications". -->
 		<FolderPath></FolderPath>
 	</Application>


### PR DESCRIPTION
Function dynamically builds out New-CMApplication command to optionally use all available parameters.
- Name is the only required field
- Icon, publisher, description, user documentation is now optional, previously required
- Split out user documentation url and optional reference
- Split out software center description and admin description
- Add optional keywords, owner, support contact, privacy url, link text, display superseded app, featured app,
- Sets administrative and user categories. Creates them if not found.

Note: When adding Owner and Support Contacts script warns of deprecation, but it's not documented on MS docs. 