### PR TITLE
Chrome

### DIFF
--- a/Disabled/GoogleChrome.xml
+++ b/Disabled/GoogleChrome.xml
@@ -83,6 +83,11 @@
 					<Is64Bit>True</Is64Bit>
 				</DetectionClause>
 			</CustomDetectionMethods>
+			<InstallBehavior>
+				<InstallBehaviorProcess DisplayName="Google Chrome">
+					<InstallBehaviorExe>chrome.exe</InstallBehaviorExe>
+				</InstallBehaviorProcess>
+			</InstallBehavior>
 			<RequirementsRules>
 				<RequirementsRule>
 					<RequirementsRuleType>Existential</RequirementsRuleType>
@@ -127,6 +132,11 @@
 					<Is64Bit>False</Is64Bit>
 				</DetectionClause>
 			</CustomDetectionMethods>
+			<InstallBehavior>
+				<InstallBehaviorProcess DisplayName="Google Chrome">
+					<InstallBehaviorExe>chrome.exe</InstallBehaviorExe>
+				</InstallBehaviorProcess>
+			</InstallBehavior>
 		</DeploymentType>
 	</DeploymentTypes>
 	<Distribution>

--- a/Disabled/GoogleChrome.xml
+++ b/Disabled/GoogleChrome.xml
@@ -49,7 +49,36 @@
 			<EstRuntimeMins>15</EstRuntimeMins>
 			<MaxRuntimeMins>30</MaxRuntimeMins>
 			<RebootBehavior>BasedOnExitCode</RebootBehavior>
-			<DetectionMethodType>MSI</DetectionMethodType>
+			<DetectionMethodType>Custom</DetectionMethodType>
+			<CustomDetectionMethods>
+				<DetectionClause>
+					<DetectionClauseType>File</DetectionClauseType>
+					<Name>chrome.exe</Name>
+					<Path>%ProgramFiles%\Google\Chrome\Application\</Path>
+					<PropertyType>Version</PropertyType>
+					<ExpectedValue>$Version</ExpectedValue>
+					<ExpressionOperator>GreaterEquals</ExpressionOperator>
+					<Value>True</Value>
+					<Is64Bit>True</Is64Bit>
+				</DetectionClause>
+				<DetectionClauseExpression>
+					<DetectionClauseConnector>
+						<ConnectorClause>1</ConnectorClause>
+						<ConnectorClauseConnector>OR</ConnectorClauseConnector>
+					</DetectionClauseConnector>
+				</DetectionClauseExpression>
+				<DetectionClause>
+					<!-- 64-bit chrome will be in ProgramFiles(x86) if upgraded from <v85 -->
+					<DetectionClauseType>File</DetectionClauseType>
+					<Name>chrome.exe</Name>
+					<Path>%ProgramFiles(x86)%\Google\Chrome\Application\</Path>
+					<PropertyType>Version</PropertyType>
+					<ExpectedValue>$Version</ExpectedValue>
+					<ExpressionOperator>GreaterEquals</ExpressionOperator>
+					<Value>True</Value>
+					<Is64Bit>True</Is64Bit>
+				</DetectionClause>
+			</CustomDetectionMethods>
 			<RequirementsRules>
 				<RequirementsRule>
 					<RequirementsRuleType>Existential</RequirementsRuleType>
@@ -79,12 +108,28 @@
 			<EstRuntimeMins>15</EstRuntimeMins>
 			<MaxRuntimeMins>30</MaxRuntimeMins>
 			<RebootBehavior>BasedOnExitCode</RebootBehavior>
-			<DetectionMethodType>MSI</DetectionMethodType>
+			<DetectionMethodType>Custom</DetectionMethodType>
+			<CustomDetectionMethods>
+				<DetectionClause>
+					<DetectionClauseType>File</DetectionClauseType>
+					<Name>chrome.exe</Name>
+					<Path>%ProgramFiles%\Google\Chrome\Application\</Path>
+					<PropertyType>Version</PropertyType>
+					<ExpectedValue>$Version</ExpectedValue>
+					<ExpressionOperator>GreaterEquals</ExpressionOperator>
+					<Value>True</Value>
+					<Is64Bit>False</Is64Bit>
+				</DetectionClause>
+			</CustomDetectionMethods>
 		</DeploymentType>
 	</DeploymentTypes>
 	<Distribution>
 		<DistributeContent>True</DistributeContent>
 	</Distribution>
+	<Supersedence>
+		<Supersedence>True</Supersedence>
+		<Uninstall>False</Uninstall>
+	</Supersedence>
 	<Deployment>
 		<DeploySoftware>True</DeploySoftware>
 	</Deployment>

--- a/Disabled/GoogleChrome.xml
+++ b/Disabled/GoogleChrome.xml
@@ -40,7 +40,9 @@
 			<ContentFallback>True</ContentFallback>
 			<OnSlowNetwork>Download</OnSlowNetwork>
 			<InstallationMSI>googlechromestandaloneenterprise64.msi</InstallationMSI>
-			<UninstallCmd></UninstallCmd>
+			<InstallProgram>msiexec.exe /i googlechromestandaloneenterprise64.msi /l*v install.log</InstallProgram>
+			<UninstallCmd>powershell.exe -noprofile -noninteractive -command ""`&amp; {exit ((Start-Process msiexec -ArgumentList /x,(gp HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\*,HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\* -ea si | ? DisplayName -eq 'Google Chrome' | select -ExpandProperty PSChildName),'/norestart','/qn','/l*v uninstall.log' -Wait -PassThru).ExitCode)}""</UninstallCmd>
+			<UninstallOption>NoneRequired</UninstallOption>
 			<Force32bit>False</Force32bit>
 			<InstallationBehaviorType>InstallForSystem</InstallationBehaviorType>
 			<LogonReqType>WhetherOrNotUserLoggedOn</LogonReqType>
@@ -99,7 +101,9 @@
 			<ContentFallback>True</ContentFallback>
 			<OnSlowNetwork>Download</OnSlowNetwork>
 			<InstallationMSI>googlechromestandaloneenterprise.msi</InstallationMSI>
-			<UninstallCmd></UninstallCmd>
+			<InstallProgram>msiexec.exe /i googlechromestandaloneenterprise.msi /l*v install.log</InstallProgram>
+			<UninstallCmd>powershell.exe -noprofile -noninteractive -command ""`&amp; {exit ((Start-Process msiexec -ArgumentList /x,(gp HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\*,HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\* -ea si | ? DisplayName -eq 'Google Chrome' | select -ExpandProperty PSChildName),'/norestart','/qn','/l*v uninstall.log' -Wait -PassThru).ExitCode)}""</UninstallCmd>
+			<UninstallOption>NoneRequired</UninstallOption>
 			<Force32bit>False</Force32bit>
 			<InstallationBehaviorType>InstallForSystem</InstallationBehaviorType>
 			<LogonReqType>WhetherOrNotUserLoggedOn</LogonReqType>

--- a/Disabled/GoogleChrome.xml
+++ b/Disabled/GoogleChrome.xml
@@ -9,6 +9,7 @@
 	</Application>
 	<Downloads>
 		<Download DeploymentType="DeploymentType1">
+			<PrefetchScript>$Download.Version = ((Invoke-RestMethod https://omahaproxy.appspot.com/all.json) | ? os -eq 'win' | select -expand versions | ? channel -eq 'stable' | select -expand version) -as [string]</PrefetchScript>
 			<URL>https://dl.google.com/edgedl/chrome/install/GoogleChromeStandaloneEnterprise64.msi</URL>
 			<DownloadFileName>googlechromestandaloneenterprise64.msi</DownloadFileName>
 			<DownloadVersionCheck>#Script to check version
@@ -19,6 +20,7 @@
 			<ExtraCopyFunctions></ExtraCopyFunctions>
 		</Download>
 		<Download DeploymentType="DeploymentType2">
+			<PrefetchScript>$Download.Version = ((Invoke-RestMethod https://omahaproxy.appspot.com/all.json) | ? os -eq 'win' | select -expand versions | ? channel -eq 'stable' | select -expand version) -as [string]</PrefetchScript>
 			<URL>https://dl.google.com/edgedl/chrome/install/GoogleChromeStandaloneEnterprise.msi</URL>
 			<DownloadFileName>googlechromestandaloneenterprise.msi</DownloadFileName>
 			<DownloadVersionCheck>#Script to check version


### PR DESCRIPTION
- Switch Chrome to file version detection to handle autoupdating & reinstalls better, including handling the 64-bit install location change
- Add an uninstall command that doesn't depend on specific product codes, by building the uninstall command from the registry
- Add a prefetch script to check the latest version from omahaproxy