### PR TITLE
Don't special-case InstallCommand handling

### DIFF
--- a/CMPackager.ps1
+++ b/CMPackager.ps1
@@ -1297,6 +1297,11 @@ Combines the output from Get-ChildItem with the Get-ExtensionAttribute function,
 					$DepTypeInstallationMSI = $DeploymentType.InstallationMSI
 					$DepTypeCommand = "Add-CMMsiDeploymentType -ApplicationName `"$DepTypeApplicationName`" -ContentLocation `"$DepTypeContentLocation\$DepTypeInstallationMSI`" -DeploymentTypeName `"$DepTypeDeploymentTypeName`""
 					$CmdSwitches = ""
+
+					If (-not ([string]::IsNullOrEmpty($DepTypeInstallationProgram))) {
+						$CmdSwitches += " -InstallCommand `"$DepTypeInstallationProgram`""
+					}
+
 					## Build the Rest of the command based on values in the xml
 					ForEach ($DepTypeVar In $(Get-Variable | Where-Object {
 								$_.Name -like "swDepType*"
@@ -1319,10 +1324,6 @@ Combines the output from Get-ChildItem with the Get-ExtensionAttribute function,
 					## Special Arguments based on Detection Method
 					Switch ($DepTypeDetectionMethodType) {
 						MSI {
-							If (-not ([string]::IsNullOrEmpty($DepTypeInstallationProgram))) {
-								$CmdSwitches += " -InstallCommand `"$DepTypeInstallationProgram`""
-							}
-						
 							$DepTypeProductCode = $DeploymentType.ProductCode
 							If (-not ([string]::IsNullOrEmpty($DepTypeProductCode))) {
 								$CMDSwitch = "-ProductCode `"$DepTypeProductCode`""
@@ -1330,8 +1331,6 @@ Combines the output from Get-ChildItem with the Get-ExtensionAttribute function,
 							}
 						}
 						CustomScript {
-							$CmdSwitches += " -InstallCommand `"$DepTypeInstallationProgram`""
-						
 							$DepTypeScriptLanguage = $DeploymentType.ScriptLanguage
 							If (-not ([string]::IsNullOrEmpty($DepTypeScriptLanguage))) {
 								$CMDSwitch = "-ScriptLanguage `"$DepTypeScriptLanguage`""

--- a/CMPackager.ps1
+++ b/CMPackager.ps1
@@ -1131,7 +1131,7 @@ Combines the output from Get-ChildItem with the Get-ExtensionAttribute function,
 		
 			# Programs
 			if (-not ([System.String]::IsNullOrEmpty($DeploymentType.InstallProgram))) {
-				$DepTypeInstallationProgram = ($DeploymentType.InstallProgram).replace('$Version', $Version).replace('$FullVersion', $AppFullVersion)
+				$stDepTypeInstallCommand = ($DeploymentType.InstallProgram).replace('$Version', $Version).replace('$FullVersion', $AppFullVersion)
 			}
 			
 			if (-not ([System.String]::IsNullOrEmpty($DeploymentType.UninstallCmd))) {
@@ -1209,9 +1209,6 @@ Combines the output from Get-ChildItem with the Get-ExtensionAttribute function,
 							$CmdSwitches += " $CmdSwitch"
 						}
 					}
-				
-					## Script Install Type Specific Arguments
-					$CmdSwitches += " -InstallCommand `'$DepTypeInstallationProgram`'"
 				
 					If ($DepTypeDetectionMethodType -eq "CustomScript") {
 						$DepTypeScriptLanguage = $DeploymentType.ScriptLanguage
@@ -1297,10 +1294,6 @@ Combines the output from Get-ChildItem with the Get-ExtensionAttribute function,
 					$DepTypeInstallationMSI = $DeploymentType.InstallationMSI
 					$DepTypeCommand = "Add-CMMsiDeploymentType -ApplicationName `"$DepTypeApplicationName`" -ContentLocation `"$DepTypeContentLocation\$DepTypeInstallationMSI`" -DeploymentTypeName `"$DepTypeDeploymentTypeName`""
 					$CmdSwitches = ""
-
-					If (-not ([string]::IsNullOrEmpty($DepTypeInstallationProgram))) {
-						$CmdSwitches += " -InstallCommand `"$DepTypeInstallationProgram`""
-					}
 
 					## Build the Rest of the command based on values in the xml
 					ForEach ($DepTypeVar In $(Get-Variable | Where-Object {


### PR DESCRIPTION
The original goal was allow `-InstallCommand` to be set with all MSI detection types, but after that I realised it could be handled with the other `stDepType*` variables, like `-UninstallCommand` etc.