### PR TITLE
Don't put quotes around get-date call

### DIFF
--- a/CMPackager.ps1
+++ b/CMPackager.ps1
@@ -599,7 +599,7 @@ Combines the output from Get-ChildItem with the Get-ExtensionAttribute function,
 		Write-Output $ApplicationDisplayName, $ApplicationPublisher, $ApplicationAutoInstall, $ApplicationDisplaySupersedence, $ApplicationIsFeatured | Out-Null
 
 		# Reference: https://docs.microsoft.com/en-us/powershell/module/configurationmanager/new-cmapplication
-		$NewAppCommand = 'New-CMApplication -Name "$ApplicationName $ApplicationSWVersion" -LocalizedName "$ApplicationDisplayName" -SoftwareVersion "$ApplicationSWVersion" -ReleaseDate "$(Get-Date)" -AutoInstall $ApplicationAutoInstall -DisplaySupersedenceInApplicationCatalog $ApplicationDisplaySupersedence -IsFeatured $ApplicationIsFeatured'
+		$NewAppCommand = 'New-CMApplication -Name "$ApplicationName $ApplicationSWVersion" -LocalizedName "$ApplicationDisplayName" -SoftwareVersion "$ApplicationSWVersion" -ReleaseDate $(Get-Date) -AutoInstall $ApplicationAutoInstall -DisplaySupersedenceInApplicationCatalog $ApplicationDisplaySupersedence -IsFeatured $ApplicationIsFeatured'
 		$CmdSwitches = ''
 	
 		## Build the rest of the command based on values in the xml


### PR DESCRIPTION
Causes a `ParameterBindingException` when calling `New-CMApplication`, possibly depending on the date or date format.