### PR TITLE
Uninstaller fixes & uninstalloptions for several recipes

### DIFF
--- a/Disabled/AzureDataStudio.xml
+++ b/Disabled/AzureDataStudio.xml
@@ -9,10 +9,11 @@
 	</Application>
 	<Downloads>
 		<Download DeploymentType="DeploymentType1">
-			<PrefetchScript>$Download.Version = (Invoke-WebRequest https://go.microsoft.com/fwlink/?linkid=2155159 -MaximumRedirection 0 -ErrorAction SilentlyContinue).Headers.Location -replace 'https://azuredatastudio-update.azurewebsites.net/' -replace '/win32-x64/stable'
+			<PrefetchScript>$Url = (Invoke-WebRequest https://azuredatastudio-update.azurewebsites.net/latest/win32-x64/stable -MaximumRedirection 0 -ErrorAction SilentlyContinue).Headers.Location
+			[string]$Download.Version = if ($Url -match '.*/azuredatastudio-windows-setup-(\d+\.\d+\.\d+)\.exe') {$matches[1]}
 			$Version = $Download.Version
 			$FullVersion = $Download.Version</PrefetchScript>
-			<URL>https://go.microsoft.com/fwlink/?linkid=2155159</URL>
+			<URL>https://azuredatastudio-update.azurewebsites.net/latest/win32-x64/stable</URL>
 			<DownloadFileName>azuredatastudio-setup.exe</DownloadFileName>
 			<Version></Version>
 			<FullVersion></FullVersion>
@@ -29,7 +30,8 @@
 			<ContentFallback>True</ContentFallback>
 			<OnSlowNetwork>Download</OnSlowNetwork>
 			<InstallProgram>azuredatastudio-setup.exe /VERYSILENT /NORESTART /MERGETASKS=!runcode</InstallProgram>
-			<UninstallCmd>`"%ProgramFiles%\Azure Data Studio\unins000.exe`" /VERYSILENT</UninstallCmd>
+			<UninstallCmd>"%ProgramFiles%\Azure Data Studio\unins000.exe" /VERYSILENT</UninstallCmd>
+			<UninstallOption>NoneRequired</UninstallOption>
 			<InstallationBehaviorType>InstallForSystem</InstallationBehaviorType>
 			<LogonReqType>WhetherOrNotUserLoggedOn</LogonReqType>
 			<UserInteractionMode>Hidden</UserInteractionMode>
@@ -48,6 +50,11 @@
 					<Value>True</Value>
 				</DetectionClause>
 			</CustomDetectionMethods>
+			<InstallBehavior>
+				<InstallBehaviorProcess DisplayName="Azure Data Studio">
+					<InstallBehaviorExe>azuredatastudio.exe</InstallBehaviorExe>
+				</InstallBehaviorProcess>
+			</InstallBehavior>
 			<RequirementsRules>
 				<RequirementsRule>
 					<RequirementsRuleType>Existential</RequirementsRuleType>
@@ -64,6 +71,7 @@
 	</Distribution>
 	<Supersedence>
 		<Supersedence>True</Supersedence>
+		<Uninstall>False</Uninstall>
 	</Supersedence>
 	<Deployment>
 		<DeploySoftware>True</DeploySoftware>

--- a/Disabled/Git.xml
+++ b/Disabled/Git.xml
@@ -51,7 +51,8 @@
 			<ContentFallback>True</ContentFallback>
 			<OnSlowNetwork>Download</OnSlowNetwork>
 			<InstallProgram>Git-x64.exe /VERYSILENT /NORESTART</InstallProgram>
-			<UninstallCmd>`"%ProgramFiles%\Git\unins000.exe`" /VERYSILENT</UninstallCmd>
+			<UninstallCmd>"%ProgramFiles%\Git\unins000.exe" /VERYSILENT</UninstallCmd>
+			<UninstallOption>NoneRequired</UninstallOption>
 			<InstallationBehaviorType>InstallForSystem</InstallationBehaviorType>
 			<LogonReqType>WhetherOrNotUserLoggedOn</LogonReqType>
 			<UserInteractionMode>Hidden</UserInteractionMode>
@@ -99,7 +100,8 @@
 			<ContentFallback>True</ContentFallback>
 			<OnSlowNetwork>Download</OnSlowNetwork>
 			<InstallProgram>Git-x86.exe /VERYSILENT /NORESTART</InstallProgram>
-			<UninstallCmd>`"%ProgramFiles(x86)%\Git\unins000.exe`" /VERYSILENT</UninstallCmd>
+			<UninstallCmd>"%ProgramFiles(x86)%\Git\unins000.exe" /VERYSILENT</UninstallCmd>
+			<UninstallOption>NoneRequired</UninstallOption>
 			<InstallationBehaviorType>InstallForSystem</InstallationBehaviorType>
 			<LogonReqType>WhetherOrNotUserLoggedOn</LogonReqType>
 			<UserInteractionMode>Hidden</UserInteractionMode>
@@ -134,6 +136,10 @@
 	<Distribution>
 		<DistributeContent>True</DistributeContent>
 	</Distribution>
+	<Supersedence>
+		<Supersedence>True</Supersedence>
+		<Uninstall>False</Uninstall>
+	</Supersedence>
 	<Deployment>
 		<DeploySoftware>True</DeploySoftware>
 	</Deployment>

--- a/Disabled/MozillaFirefox.xml
+++ b/Disabled/MozillaFirefox.xml
@@ -12,6 +12,7 @@
 			<URL>https://download.mozilla.org/?product=firefox-msi-latest-ssl&amp;os=win64&amp;lang=en-US</URL>
 			<DownloadFileName>Firefoxx64.msi</DownloadFileName>
 			<DownloadVersionCheck>$Version = ([String](Get-MSIInfo -Path $DownloadFile -Property ProductVersion)).TrimStart().TrimEnd()</DownloadVersionCheck>
+			<AppRepoFolder>x64</AppRepoFolder>
 			<FullVersion></FullVersion>
 			<Version></Version>
 		</Download>
@@ -19,6 +20,7 @@
 			<URL>https://download.mozilla.org/?product=firefox-msi-latest-ssl&amp;os=win&amp;lang=en-US</URL>
 			<DownloadFileName>Firefoxx86.msi</DownloadFileName>
 			<DownloadVersionCheck>$Version = ([String](Get-MSIInfo -Path $DownloadFile -Property ProductVersion)).TrimStart().TrimEnd()</DownloadVersionCheck>
+			<AppRepoFolder>x86</AppRepoFolder>
 			<FullVersion></FullVersion>
 			<Version></Version>
 		</Download>
@@ -29,8 +31,9 @@
 			<InstallationType>Script</InstallationType>
 			<ContentFallback>True</ContentFallback>
 			<OnSlowNetwork>Download</OnSlowNetwork>
-			<InstallProgram>msiexec.exe /i Firefoxx64.msi /qn /norestart</InstallProgram>
-			<UninstallCmd>`"%ProgramFiles%\Mozilla Firefox\uninstall\helper.exe`" -ms</UninstallCmd>
+			<InstallProgram>msiexec.exe /i Firefoxx64.msi /qn /norestart /l*v install.log</InstallProgram>
+			<UninstallCmd>"%ProgramFiles%\Mozilla Firefox\uninstall\helper.exe" -ms</UninstallCmd>
+			<UninstallOption>NoneRequired</UninstallOption>
 			<InstallationBehaviorType>InstallForSystem</InstallationBehaviorType>
 			<LogonReqType>WhetherOrNotUserLoggedOn</LogonReqType>
 			<UserInteractionMode>Hidden</UserInteractionMode>
@@ -50,6 +53,11 @@
 					<Is64Bit>True</Is64Bit>
 				</DetectionClause>
 			</CustomDetectionMethods>
+			<InstallBehavior>
+				<InstallBehaviorProcess DisplayName="Mozilla Firefox">
+					<InstallBehaviorExe>firefox.exe</InstallBehaviorExe>
+				</InstallBehaviorProcess>
+			</InstallBehavior>
 			<RequirementsRules>
 				<RequirementsRule>
 					<RequirementsRuleType>Existential</RequirementsRuleType>
@@ -65,8 +73,9 @@
 			<InstallationType>Script</InstallationType>
 			<ContentFallback>True</ContentFallback>
 			<OnSlowNetwork>Download</OnSlowNetwork>
-			<InstallProgram>msiexec.exe /i Firefoxx86.msi /qn /norestart</InstallProgram>
-			<UninstallCmd>`"%ProgramFiles%\Mozilla Firefox\uninstall\helper.exe`" -ms</UninstallCmd>
+			<InstallProgram>msiexec.exe /i Firefoxx86.msi /qn /norestart /l*v install.log</InstallProgram>
+			<UninstallCmd>"%ProgramFiles%\Mozilla Firefox\uninstall\helper.exe" -ms</UninstallCmd>
+			<UninstallOption>NoneRequired</UninstallOption>
 			<InstallationBehaviorType>InstallForSystem</InstallationBehaviorType>
 			<LogonReqType>WhetherOrNotUserLoggedOn</LogonReqType>
 			<UserInteractionMode>Hidden</UserInteractionMode>
@@ -86,6 +95,11 @@
                     <Is64Bit>False</Is64Bit>
 				</DetectionClause>
 			</CustomDetectionMethods>
+			<InstallBehavior>
+				<InstallBehaviorProcess DisplayName="Mozilla Firefox">
+					<InstallBehaviorExe>firefox.exe</InstallBehaviorExe>
+				</InstallBehaviorProcess>
+			</InstallBehavior>
 		</DeploymentType>
 	</DeploymentTypes>
 	<Distribution>
@@ -97,5 +111,6 @@
 	</Supersedence>
 	<Deployment>
 		<DeploySoftware>True</DeploySoftware>
+		<UpdateSuperseded>True</UpdateSuperseded>
 	</Deployment>
 </ApplicationDef>

--- a/Disabled/PowerShell.xml
+++ b/Disabled/PowerShell.xml
@@ -9,10 +9,9 @@
 	</Application>
 	<Downloads>
 		<Download DeploymentType="DeploymentType1">
-			<PrefetchScript>$content = Invoke-WebRequest https://github.com/PowerShell/PowerShell/releases/latest -UseBasicParsing
-			$LinkPath = ($content | Select-Object -ExpandProperty Links | Where-Object -Property href -Like "*PowerShell-*-win-x64.msi").href
-			$URL = "https://github.com$LinkPath"
-			$Download.Version = if ($url -match "\d+\.\d+\.\d+(\.\d+)?") {$matches[0] + '.0'}
+			<PrefetchScript>$v = (Invoke-RestMethod https://aka.ms/pwsh-buildinfo-stable).ReleaseTag -replace '^v'
+			$download.version = $v + '.0'
+			$url = 'https://github.com/PowerShell/PowerShell/releases/download/v{0}/PowerShell-{0}-win-x64.msi' -f $v
 			</PrefetchScript>
 			<URL></URL>
 			<DownloadFileName>PowerShell.msi</DownloadFileName>
@@ -57,6 +56,11 @@
 					<Value>True</Value>
 				</DetectionClause>
 			</CustomDetectionMethods>
+			<InstallBehavior>
+				<InstallBehaviorProcess DisplayName="PowerShell">
+					<InstallBehaviorExe>pwsh.exe</InstallBehaviorExe>
+				</InstallBehaviorProcess>
+			</InstallBehavior>
 			<RequirementsRules>
 				<RequirementsRule>
 					<RequirementsRuleType>Existential</RequirementsRuleType>
@@ -69,12 +73,14 @@
 		</DeploymentType>
 	</DeploymentTypes>
 	<Distribution>
-		<DistributeContent>False</DistributeContent>
+		<DistributeContent>True</DistributeContent>
 	</Distribution>
 	<Supersedence>
 		<Supersedence>True</Supersedence>
+		<Uninstall>False</Uninstall>
 	</Supersedence>
 	<Deployment>
-		<DeploySoftware>False</DeploySoftware>
+		<DeploySoftware>True</DeploySoftware>
+		<UpdateSuperseded>True</UpdateSuperseded>
 	</Deployment>
 </ApplicationDef>

--- a/Disabled/VisualStudioCode.xml
+++ b/Disabled/VisualStudioCode.xml
@@ -16,6 +16,7 @@
 			<FullVersion></FullVersion>
 			<DownloadVersionCheck>$Version = ((Get-item $TempDir\$DownloadFileName).VersionInfo.FileVersion).trimstart().TrimEnd()
 			$FullVersion = "$Version.0"</DownloadVersionCheck>
+			<AppRepoFolder>x64</AppRepoFolder>
 			<ExtraCopyFunctions></ExtraCopyFunctions>
 		</Download>
 		<Download DeploymentType="DeploymentType2">
@@ -26,6 +27,7 @@
 			<FullVersion></FullVersion>
 			<DownloadVersionCheck>$Version = ((Get-item $TempDir\$DownloadFileName).VersionInfo.FileVersion).TrimStart().TrimEnd()
 			$FullVersion = "$Version.0"</DownloadVersionCheck>
+			<AppRepoFolder>x86</AppRepoFolder>
 			<ExtraCopyFunctions></ExtraCopyFunctions>
 		</Download>
 	</Downloads>
@@ -38,7 +40,8 @@
 			<ContentFallback>True</ContentFallback>
 			<OnSlowNetwork>Download</OnSlowNetwork>
 			<InstallProgram>VSCodeSetup-x64.exe /VERYSILENT /NORESTART /MERGETASKS=!runcode</InstallProgram>
-			<UninstallCmd>`"%ProgramFiles%\Microsoft VS Code\unins000.exe`" /VERYSILENT</UninstallCmd>
+			<UninstallCmd>"%ProgramFiles%\Microsoft VS Code\unins000.exe" /VERYSILENT</UninstallCmd>
+			<UninstallOption>NoneRequired</UninstallOption>
 			<InstallationBehaviorType>InstallForSystem</InstallationBehaviorType>
 			<LogonReqType>WhetherOrNotUserLoggedOn</LogonReqType>
 			<UserInteractionMode>Hidden</UserInteractionMode>
@@ -57,6 +60,11 @@
 					<Value>True</Value>
 				</DetectionClause>
 			</CustomDetectionMethods>
+			<InstallBehavior>
+				<InstallBehaviorProcess DisplayName="Visual Studio Code">
+					<InstallBehaviorExe>Code.exe</InstallBehaviorExe>
+				</InstallBehaviorProcess>
+			</InstallBehavior>
 			<RequirementsRules>
 				<RequirementsRule>
 					<RequirementsRuleType>Existential</RequirementsRuleType>
@@ -75,7 +83,8 @@
 			<ContentFallback>True</ContentFallback>
 			<OnSlowNetwork>Download</OnSlowNetwork>
 			<InstallProgram>VSCodeSetup-ia32.exe /VERYSILENT /NORESTART /MERGETASKS=!runcode</InstallProgram>
-			<UninstallCmd>`"%ProgramFiles(x86)%\Microsoft VS Code\unins000.exe`" /VERYSILENT</UninstallCmd>
+			<UninstallCmd>"%ProgramFiles(x86)%\Microsoft VS Code\unins000.exe" /VERYSILENT</UninstallCmd>
+			<UninstallOption>NoneRequired</UninstallOption>
 			<InstallationBehaviorType>InstallForSystem</InstallationBehaviorType>
 			<LogonReqType>WhetherOrNotUserLoggedOn</LogonReqType>
 			<UserInteractionMode>Hidden</UserInteractionMode>
@@ -94,11 +103,20 @@
 					<Value>True</Value>
 				</DetectionClause>
 			</CustomDetectionMethods>
+			<InstallBehavior>
+				<InstallBehaviorProcess DisplayName="Visual Studio Code">
+					<InstallBehaviorExe>Code.exe</InstallBehaviorExe>
+				</InstallBehaviorProcess>
+			</InstallBehavior>
 		</DeploymentType>
 	</DeploymentTypes>
 	<Distribution>
 		<DistributeContent>True</DistributeContent>
 	</Distribution>
+	<Supersedence>
+		<Supersedence>True</Supersedence>
+		<Uninstall>False</Uninstall>
+	</Supersedence>
 	<Deployment>
 		<DeploySoftware>True</DeploySoftware>
 	</Deployment>

--- a/Disabled/vcxsrv.xml
+++ b/Disabled/vcxsrv.xml
@@ -15,7 +15,7 @@ $URL = $downloadurl
 $version = $downloadurl -replace '^.*vcxsrv-64\.' -replace '\.installer\.exe/download'
 $download.Version = $version
 $FullVersion = $version
-$PSDefaultParameterValues.Add('Invoke-WebRequest:UserAgent','NotABrowser')</PrefetchScript>
+if (!($PSDefaultParameterValues.ContainsKey('Invoke-WebRequest:UserAgent'))) {$PSDefaultParameterValues.Add('Invoke-WebRequest:UserAgent','NotABrowser')}</PrefetchScript>
 			<!-- SourceForge will only present the file to a non-browser user agent -->
 			<DownloadFileName>vcxsrv-64.exe</DownloadFileName>
 			<Version></Version>
@@ -32,7 +32,7 @@ $URL = $downloadurl
 $version = $downloadurl -replace '^.*vcxsrv\.' -replace '\.installer\.exe/download'
 $download.Version = $version
 $FullVersion = $version
-$PSDefaultParameterValues.Add('Invoke-WebRequest:UserAgent','NotABrowser')</PrefetchScript>
+if (!($PSDefaultParameterValues.ContainsKey('Invoke-WebRequest:UserAgent'))) {$PSDefaultParameterValues.Add('Invoke-WebRequest:UserAgent','NotABrowser')}</PrefetchScript>
 			<!-- SourceForge will only present the file to a non-browser user agent -->
 			<DownloadFileName>vcxsrv-86.exe</DownloadFileName>
 			<Version></Version>
@@ -53,6 +53,7 @@ $PSDefaultParameterValues.Add('Invoke-WebRequest:UserAgent','NotABrowser')</Pref
 			<OnSlowNetwork>Download</OnSlowNetwork>
 			<InstallProgram>vcxsrv-64.exe /S</InstallProgram>
 			<UninstallCmd>%ProgramFiles%\VcXsrv\uninstall.exe /S</UninstallCmd>
+			<UninstallOption>NoneRequired</UninstallOption>
 			<InstallationBehaviorType>InstallForSystem</InstallationBehaviorType>
 			<LogonReqType>WhetherOrNotUserLoggedOn</LogonReqType>
 			<UserInteractionMode>Hidden</UserInteractionMode>
@@ -71,6 +72,14 @@ $PSDefaultParameterValues.Add('Invoke-WebRequest:UserAgent','NotABrowser')</Pref
 					<Value>True</Value>
 				</DetectionClause>
 			</CustomDetectionMethods>
+			<InstallBehavior>
+				<InstallBehaviorProcess DisplayName="VcXsrv">
+					<InstallBehaviorExe>vcxsrv.exe</InstallBehaviorExe>
+				</InstallBehaviorProcess>
+				<InstallBehaviorProcess DisplayName="XLaunch">
+					<InstallBehaviorExe>xlaunch.exe</InstallBehaviorExe>
+				</InstallBehaviorProcess>
+			</InstallBehavior>
 			<RequirementsRules>
 				<RequirementsRule>
 					<RequirementsRuleType>Existential</RequirementsRuleType>
@@ -90,6 +99,7 @@ $PSDefaultParameterValues.Add('Invoke-WebRequest:UserAgent','NotABrowser')</Pref
 			<OnSlowNetwork>Download</OnSlowNetwork>
 			<InstallProgram>vcxsrv-86.exe /S</InstallProgram>
 			<UninstallCmd>%ProgramFiles%\VcXsrv\uninstall.exe /S</UninstallCmd>
+			<UninstallOption>NoneRequired</UninstallOption>
 			<InstallationBehaviorType>InstallForSystem</InstallationBehaviorType>
 			<LogonReqType>WhetherOrNotUserLoggedOn</LogonReqType>
 			<UserInteractionMode>Hidden</UserInteractionMode>
@@ -108,6 +118,14 @@ $PSDefaultParameterValues.Add('Invoke-WebRequest:UserAgent','NotABrowser')</Pref
 					<Value>True</Value>
 				</DetectionClause>
 			</CustomDetectionMethods>
+			<InstallBehavior>
+				<InstallBehaviorProcess DisplayName="VcXsrv">
+					<InstallBehaviorExe>vcxsrv.exe</InstallBehaviorExe>
+				</InstallBehaviorProcess>
+				<InstallBehaviorProcess DisplayName="XLaunch">
+					<InstallBehaviorExe>xlaunch.exe</InstallBehaviorExe>
+				</InstallBehaviorProcess>
+			</InstallBehavior>
 		</DeploymentType>
 	</DeploymentTypes>
 	<Distribution>


### PR DESCRIPTION
- Script installation types don't do string expansion on UninstallCmd, so the backticks to escape quotes get removed.
- UninstallOption NoneRequired set where appropriate
- Some InstallBehaviours set