### PR TITLE
Update CMPackager.ps1 to Allow for Dynamic Versioning in Detection Paths

### DIFF
--- a/CMPackager.ps1
+++ b/CMPackager.ps1
@@ -799,6 +799,7 @@ Combines the output from Get-ChildItem with the Get-ExtensionAttribute function,
 			$detMethodCommand += " -Is64Bit"
 		}
 		If (-not ([System.String]::IsNullOrEmpty($DetectionMethod.Path))) {
+			$DetectionMethod.Path = ($DetectionMethod.Path).replace('$Version', $Version).replace('$FullVersion', $AppFullVersion)
 			$detMethodCommand += " -Path `'$($DetectionMethod.Path)`'"
 		}
 		If (-not ([System.String]::IsNullOrEmpty($DetectionMethod.PropertyType))) {
@@ -818,6 +819,7 @@ Combines the output from Get-ChildItem with the Get-ExtensionAttribute function,
 			$detMethodCommand += " -Hive $($DetectionMethod.Hive)"
 		}
 		If (-not ([System.String]::IsNullOrEmpty($DetectionMethod.KeyName))) {
+			$DetectionMethod.KeyName = ($DetectionMethod.KeyName).replace('$Version', $Version).replace('$FullVersion', $AppFullVersion)
 			$detMethodCommand += " -KeyName `"$($DetectionMethod.KeyName)`""
 		}
 		If (-not ([System.String]::IsNullOrEmpty($DetectionMethod.ValueName))) {


### PR DESCRIPTION
Adding two lines to allow for dynamic versioning in the registry key path and the file detection paths when the program installations add those for each version. This is similar to how the ExpectedValue is handle.