### PR TITLE
Adding superseded application cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,8 @@ CMPackager.prefs
 # Ignore Recipes Folder
 Recipes/*
 
+# Ignore vscode
+.vscode/*
+
 # Except for the Template.xml
 !Recipes/Template.xml

--- a/Disabled/_RecipeSchema.xsd
+++ b/Disabled/_RecipeSchema.xsd
@@ -222,6 +222,8 @@
             <xs:all>
               <xs:element name="Supersedence" type="xs:string" minOccurs="0" />
               <xs:element name="Uninstall" type="xs:string" minOccurs="0" />
+              <xs:element name="CleanupSuperseded" type="xs:string" minOccurs="0" />
+              <xs:element name="KeepSuperseded" type="xs:string" minOccurs="0" />
             </xs:all>
           </xs:complexType>
         </xs:element>


### PR DESCRIPTION
This is a proposed fix for #113 

Adds a function to cleanup superseded applications as part of the run.  The recipe schema changes just a little bit - a line to turn it on, and a line for how many to keep. 