### PR TITLE
Add recipe deployment option available/required

### DIFF
--- a/CMPackager.ps1
+++ b/CMPackager.ps1
@@ -1602,13 +1602,16 @@ Combines the output from Get-ChildItem with the Get-ExtensionAttribute function,
 				$DeploymentSplat = @{
 					Name = "$ApplicationName $ApplicationSWVersion"
 					DeployAction = 'Install'
-					DeployPurpose = 'Available'
 					UserNotification = 'DisplaySoftwareCenterOnly'
 					UpdateSupersedence = [System.Convert]::ToBoolean($Deployment.UpdateSuperseded)
 					AllowRepairApp = [System.Convert]::ToBoolean($Deployment.AllowRepair)
 					ErrorAction = 'Stop'
 				}
 
+				if (-not ([string]::IsNullOrEmpty($Deployment.Purpose))) {
+					$DeploymentSplat['DeployPurpose'] = $Deployment.Purpose
+				}
+				
 				if (-not ([string]::IsNullOrEmpty($Deployment.AvailableOffset))) {
 					$DeploymentSplat['AvailableDateTime'] = (Get-Date) + $Deployment.AvailableOffset
 				}

--- a/CMPackager.ps1
+++ b/CMPackager.ps1
@@ -36,7 +36,7 @@ param (
 		}
 		return $true
 	})]
-	[System.IO.FileInfo]$RecipePath = "$PSScriptRoot\Recipes"
+	[System.IO.DirectoryInfo]$RecipePath = "$PSScriptRoot\Recipes"
 )
 DynamicParam {
 	# If RecipePath is specified populate list of available recipes from custom recipe location  

--- a/Recipes/Template.xml
+++ b/Recipes/Template.xml
@@ -391,6 +391,8 @@
 	<Deployment>
 		<!-- DeploySoftware - [Boolean] Switch for Software Deployment, Application should be distributed before deployment -->
 		<DeploySoftware></DeploySoftware>
+		<!-- Purpose - Whether the deployment is mandatory or optional. Defaults to Available if not specified -->
+		<Purpose>[Required/Available]</Purpose>
 		<!-- UpdateSuperseded - [Boolean] Whether the deployment should automatically upgrade superseded versions -->
 		<UpdateSuperseded></UpdateSuperseded>
 		<!-- DeadlineOffset - [TimeSpan] Time after deployment that install will be enforced. Requires UpdateSuperseded = true for available deployments, eg 1.23:45 for 1 day, 23 hours, 45 minutes. https://docs.microsoft.com/en-us/dotnet/standard/base-types/standard-timespan-format-strings -->


### PR DESCRIPTION
Removes the hardcoded "available" deployment purpose and instead uses the value specified in the new "Purpose" option in recipes. New-CMApplicationDeployment defaults to "available" if -DeployPurpose is not specified.

Fixed the SingleRecipe dynamic parameter so it won’t complain about an unresolved part when not explicitly specifying -RecipePath. Also amended the parameter logic to only consider xml files and fall back to the standard recipe directory if called from the CMpackager directory. 

Lastly a minor fix to the cast of RecipePath parameter from file to directory. 

These should help address #128 , #134 and #138 