### PR TITLE
Update supersedence cmdlet

### DIFF
--- a/CMPackager.ps1
+++ b/CMPackager.ps1
@@ -1704,10 +1704,10 @@ Combines the output from Get-ChildItem with the Get-ExtensionAttribute function,
 					Write-Host "Superseding $($DeploymentType.LocalizedDisplayName)"
 					$SupersededDeploymentType = $OldAppDeploymentTypes | Where-Object LocalizedDisplayName -eq $DeploymentType.LocalizedDisplayName
 					if ($UninstallOldApp) {
-						Add-CMDeploymentTypeSupersedence -SupersedingDeploymentType $DeploymentType -SupersededDeploymentType $SupersededDeploymentType -IsUninstall $true | Out-Null
+						Set-CMApplicationSupersedence -DeploymentType $DeploymentType -SupersedingDeploymentType $SupersededDeploymentType -IsUninstall $true | Out-Null
 					}
 					else {
-						Add-CMDeploymentTypeSupersedence -SupersedingDeploymentType $DeploymentType -SupersededDeploymentType $SupersededDeploymentType | Out-Null
+						Set-CMApplicationSupersedence -DeploymentType $DeploymentType -SupersedingDeploymentType $SupersededDeploymentType -IsUninstall $false | Out-Null
 					}
 				}
 			}


### PR DESCRIPTION
Cmdlet Add-CMDeploymentTypeSupersedence is deprecated and may be removed in a future release.
Use the Set-CMApplicationSupersedence cmdlet instead.

Fix for issue https://github.com/asjimene/CMPackager/issues/141 